### PR TITLE
add a "reflected XSS" vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ Less than 30 lines of Python + 40 lines HTML template.
 As you started the flask app in development mode, any source changes should apply immediately so you can just refresh
 the page. If you want to clear the database, just delete the `database.db` file that is (re-)created on first use.
 
+If you are running flask directly and want to run it on all your IP addresses so that others on your LAN can access it (e.g., for a classroom demo -- please do not use this for production on the Internet!), you can do:
+
+```
+$ flask run --host=0.0.0.0
+```
+
+Again, this should only be used temporarily and in a relatively safe environment.
+
 # Making it vulnerable
 
 To demonstrate XSS flaws you can change 

--- a/app.py
+++ b/app.py
@@ -6,6 +6,11 @@ app = Flask(__name__)
 
 @app.route('/', methods=['GET', 'POST'])
 def index():
+
+    name = ''
+    if request.method == 'GET':
+        name = request.args.get('name','')
+
     if request.method == 'POST':
         db.add_comment(request.form['comment'])
 
@@ -14,5 +19,6 @@ def index():
     comments = db.get_comments(search_query)
 
     return render_template('index.html',
+                           name=name,
                            comments=comments,
                            search_query=search_query)

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,6 +12,9 @@
     <!-- Header -->
     <header>
       <h1>XSS Demo</h1>
+		{% if name %}
+			<p>Welcome, {{ name }}!</p>
+		{% endif %}
       <p>Read, search and post comments</p>
     </header>
 


### PR DESCRIPTION
This commit adds a URL parameter, 'name', that is used in a welcome message if it exists. The name is unsanitized and so can include JS and thus cause an XSS that runs on the client side but does not exist on the server side (i.e., a "reflected XSS").

The behavior of the system is unchanged if you go to the bare URL, e.g., http://127.0.0.1:5000/ -- however, if you add a 'name' parameter to the URL, e.g., http://127.0.0.1:5000?name=Peter it will display a welcome message between "XSS Demo" and "Read, Search, and Post Comments".

The name parameter can contain JS, e.g.:
http://127.0.0.1:5000?name=Peter<script>alert("boo")</script>

... and this JS will run in the page.

Sanitization should be the same in either case, i.e., setting autoescape to true in the template.